### PR TITLE
Adding tootip functionality

### DIFF
--- a/bootstrap-shortcodes.php
+++ b/bootstrap-shortcodes.php
@@ -63,6 +63,7 @@ class BoostrapShortcodes {
     add_shortcode('well', array( $this, 'bs_well' ));
     add_shortcode('tabs', array( $this, 'bs_tabs' ));
     add_shortcode('tab', array( $this, 'bs_tab' ));
+    add_shortcode('tooltip', array( $this, 'bs_tooltip' ));
 
   }
 
@@ -468,6 +469,21 @@ class BoostrapShortcodes {
       </div>
     </div>
     ';
+  }
+
+  function bs_tooltip( $atts, $content = null ) {
+    
+    $defaults = array( 
+	'title' => '', 
+	'placement' => 'top',
+	'animation' => 'true',
+	'html' => 'false'
+    );
+    extract( shortcode_atts( $defaults, $atts ) );
+
+    wp_enqueue_script( 'bootsrap-shortcodes-tooltip', plugins_url( 'js/bootstrap-shortcodes-tooltip.js', __FILE__ ), array( 'jquery' ), false, true );
+
+    return '<a href="#" class="bs-tooltip" data-toggle="tooltip" title="' . $title . '" data-placement="' . $placement . '" data-animation="' . $animation . '" data-html="' . $html . '">' . $content . '</a>';
   }
 
 }

--- a/js/bootstrap-shortcodes-tooltip.js
+++ b/js/bootstrap-shortcodes-tooltip.js
@@ -1,0 +1,3 @@
+(function($) {
+	$('.bs-tooltip').tooltip();
+})(jQuery);


### PR DESCRIPTION
Added the [tooltip] shortcode which allows a user to easily add tooltips to their content.

Usage:
[tooltip title="this is in the tooltip"]...[tooltip]

Additional paraemters:
placement
    description: the placement of the tooltip
    values: top|bottom|left|right
    default: top
animation
    decripion: apply a css fade to the tooltip on show/hide
    values: true|false
    default: true
html
    description: allow use of html in the tooltip
    values: true|false
    default: false
