### PR TITLE
Fixing empty p tag issue

### DIFF
--- a/bootstrap-shortcodes.php
+++ b/bootstrap-shortcodes.php
@@ -34,6 +34,8 @@ License: GPL2
 class BoostrapShortcodes {
 
   function __construct() {
+    remove_filter( 'the_content', 'wpautop' );
+    add_filter( 'the_content', 'wpautop' , 12);
     add_action( 'init', array( $this, 'add_shortcodes' ) ); 
   }
 


### PR DESCRIPTION
Resolving issue filipstefansson/bootstrap-shortcodes#4.
Single line shortcodes are no longer wrapped by p tags.
