### PR TITLE
Update Composer installer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,6 @@
   "type": "wordpress-plugin",
   "require": {
     "php": ">=5.3.2",
-    "composer/installers": "v1.0.6"
+    "composer/installers": "1.0.*@dev"
   }
 }


### PR DESCRIPTION
People with updated versions of Composer can't install this as a dependency because of the hard 1.0.6 requirement. This PR should resolve that issue.
