### PR TITLE
Allows user to define constant to disable scripts

### DIFF
--- a/bootstrap-shortcodes.php
+++ b/bootstrap-shortcodes.php
@@ -41,6 +41,10 @@ class BoostrapShortcodes {
 
   function bootstrap_shortcodes_scripts()  { 
 
+    if (defined('LOAD_BS_SHORTCODES_SCRIPTS') && LOAD_BS_SHORTCODES_SCRIPTS!==true) {
+        return;
+    }
+    
     // Bootstrap tooltip js
     wp_enqueue_script( 'bootstrap-shortcodes-tooltip', BS_SHORTCODES_URL . 'js/bootstrap-shortcodes-tooltip.js', array( 'jquery' ), false, true );
     


### PR DESCRIPTION
Setting `LOAD_BS_SHORTCODES_SCRIPTS` to `false` (or anything other than `true`) will cause the function that loads the scripts to exit without enqueuing the scripts.

This is useful when users concatenate and uglify their JS.

NOTE: scripts load fine when constant is not defined.

This PR is one of many ways this could be accomplished. It was just the fastest way I could think of that will have a very minimal impact on your plugin.
