### PR TITLE
* added callout, cards, modified panels and added row-container

### DIFF
--- a/includes/css/wp-bootstrap-callout-test.html
+++ b/includes/css/wp-bootstrap-callout-test.html
@@ -1,0 +1,45 @@
+<div class="bs-callout bs-callout-default">
+  <h4>Default Callout</h4>
+  This is a default callout, large (default size).
+</div>
+
+<div class="bs-callout bs-callout-primary bs-callout-xl">
+  <h4>Primary Callout + xl</h4>
+  This is a primary callout, xtra large (100% width). It has no background.
+</div>
+
+<div class="bs-callout bs-callout-success bs-callout-lg">
+  <h4>Success Callout + lg</h4>
+  This is a success callout, large.
+</div>
+<div class="bs-callout bs-callout-success bs-callout-lg transparent">
+  <h4>Success Callout + lg + transparent</h4>
+  This is a success callout, large and transparent.
+</div>
+<div class="bs-callout bs-callout-success bs-callout-lg disabled">
+  <h4>Success Callout + lg + disabled</h4>
+  This is a success callout, large and disabled.
+</div>
+
+<div class="bs-callout bs-callout-info bs-callout-md">
+  <h4>Info Callout + md</h4>
+  This is an info callout, medium.
+</div>
+
+<div class="bs-callout bs-callout-warning bs-callout-sm">
+  <h4>Warning Callout + sm</h4>
+  This is a warning callout, small.
+</div>
+<div class="bs-callout bs-callout-warning bs-callout-sm transparent">
+  <h4>Warning Callout + sm + transparent</h4>
+  This is a warning callout, small and transparent.
+</div>
+
+<div class="bs-callout bs-callout-danger bs-callout-xs">
+  <h4>Danger Callout + xs</h4>
+  This is a danger callout, xtra small.
+</div>
+<div class="bs-callout bs-callout-danger bs-callout-xs disabled">
+  <h4>Danger Callout + xs + transparent</h4>
+  This is a danger callout, xtra small.
+</div>

--- a/includes/css/wp-bootstrap-callout.css
+++ b/includes/css/wp-bootstrap-callout.css
@@ -1,0 +1,97 @@
+/* Bootstrap callout */ 
+.bs-callout {
+  padding: 20px;
+  margin: 20px 0;
+  border: 1px solid #eee;
+  border-left-width: 5px;
+  border-radius: 4px;
+  margin-left: 50px;
+}
+.bs-callout-xl {
+  margin-left: 0px;
+}
+.bs-callout-lg {
+  margin-left: 50px;
+}
+.bs-callout-md {
+  margin-left: 100px;
+}
+.bs-callout-sm {
+  margin-left: 150px;
+}
+.bs-callout-xs {
+  margin-left: 200px;
+}
+.bs-callout h4 {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+.bs-callout p:last-child {
+  margin-bottom: 0;
+}
+.bs-callout code {
+  border-radius: 4px;
+}
+.bs-callout+.bs-callout {
+  margin-top: -5px;
+}
+.bs-callout-default {
+  border-left-color: #777;
+  background-color: #f7f7f9;
+}
+.bs-callout-default h4 {
+  color: #777;
+}
+.bs-callout-primary {
+  border-left-color: #428bca;
+}
+.bs-callout-primary h4 {
+  color: #428bca;
+}
+.bs-callout-success {
+  border-left-color: #5cb85c;
+  background-color: #efffe8;
+}
+.bs-callout-success h4 {
+  color: #5cb85c;
+}
+.bs-callout-danger {
+  border-left-color: #d9534f;
+  background-color: #fcf2f2;
+}
+.bs-callout-danger h4 {
+  color: #d9534f;
+}
+.bs-callout-warning {
+  border-left-color: #f0ad4e;
+  background-color: #fefbed;
+}
+.bs-callout-warning h4 {
+  color: #f0ad4e;
+}
+.bs-callout-info {
+  border-left-color: #5bc0de;
+  background-color: #f0f7fd;
+}
+.bs-callout-info h4 {
+  color: #5bc0de;
+}
+/* bg transparency and disabled effects for Bootstrap callout */ 
+.bs-callout-default.transparent {
+  background-color: rgb(247, 247, 249, 0.7); /*#f7f7f9*/
+}
+.bs-callout-success.transparent {
+  background-color: rgb(239, 255, 232, 0.7); /*#efffe8*/
+}
+.bs-callout-warning.transparent {
+  background-color: rgb(254, 251, 237, 0.7); /*#fefbed*/
+}
+.bs-callout-danger.transparent {
+  background-color: rgb(252, 242, 242, 0.7); /*#fcf2f2*/
+}
+.bs-callout-info.transparent {
+  background-color: rgb(240, 247, 253, 0.7); /*#f0f7fd*/
+}
+.bs-callout.disabled {
+  opacity: 0.4;
+}

--- a/includes/css/wp-bootstrap4-cards-test.html
+++ b/includes/css/wp-bootstrap4-cards-test.html
@@ -1,0 +1,84 @@
+<div class="container">
+<div class="row">
+<div class="col-12 col-md-9 pull-md-3">
+
+
+<div class="card-columns">
+  <div class="card">
+    <img class="card-img-top img-fluid" src="https://dummyimage.com/300x160" alt="Card image cap">
+    <div class="card-block">
+      <h4 class="card-title">Card title 1 that wraps to a new line</h4>
+      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+    </div>
+  </div>
+  
+  <div class="card">
+  <div class="card-header">
+    Featured
+  </div>
+  <div class="card-block bg-success p-4">
+    <blockquote class="card-block card-blockquote">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+    </blockquote>
+    <p class="card-text">This is a longer card with supporting text below</p>
+  </div>
+      <div class="card-footer">
+        <small class="text-muted">
+          Someone famous in <cite title="Source Title">Source Title</cite>
+        </small>
+      </div>
+  </div>
+  
+  <div class="card">
+    <img class="card-img-top img-fluid" src="https://dummyimage.com/242x160" alt="Card image cap">
+    <div class="card-block bg-danger">
+      <h4 class="card-title">Card title</h4>
+      <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
+      <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+    </div>
+  </div>
+  
+  <div class="card card-inverse card-primary p-3 text-center">
+    <blockquote class="card-blockquote">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat.</p>
+      <footer>
+        <small>
+          Someone famous in <cite title="Source Title">Source Title</cite>
+        </small>
+      </footer>
+    </blockquote>
+  </div>
+  
+  <div class="card text-center">
+    <div class="card-block">
+      <h4 class="card-title">Card title 1</h4>
+      <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
+      <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+    </div>
+  </div>
+  
+  <div class="card">
+    <img class="card-img img-fluid" src="https://dummyimage.com/242x260" alt="Card image">
+  </div>
+  <div class="card p-3 text-right">
+    <blockquote class="card-blockquote">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+      <footer>
+        <small class="text-muted">
+          Someone famous in <cite title="Source Title">Source Title</cite>
+        </small>
+      </footer>
+    </blockquote>
+  </div>
+  
+  <div class="card">
+    <div class="card-block bg-info">
+      <h4 class="card-title">Card title 2</h4>
+      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+      <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+    </div>
+  </div>
+</div>
+
+</div>
+</div>

--- a/includes/css/wp-bootstrap4-cards.css
+++ b/includes/css/wp-bootstrap4-cards.css
@@ -1,0 +1,280 @@
+.img-fluid {
+    max-width: 100%;
+    height: auto;
+}
+.card{
+  position:relative;
+  display:-webkit-box;
+  display:-webkit-flex;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-box-orient:vertical;
+  -webkit-box-direction:normal;
+  -webkit-flex-direction:column;
+  -ms-flex-direction:column;
+  flex-direction:column;
+  background-color:#fff;
+  border:1px solid rgba(0,0,0,.125);
+  border-radius:.5rem
+}
+.card-block{
+  -webkit-box-flex:1;
+  -webkit-flex:1 1 auto;
+  -ms-flex:1 1 auto;
+  flex:1 1 auto;
+  padding:1.25rem
+}
+.card-title{
+  margin-bottom:.75rem
+}
+.card-subtitle{
+  margin-top:-.375rem;
+  margin-bottom:0
+}
+.card-text:last-child{
+  margin-bottom:0
+}
+.card-link:hover{
+  text-decoration:none
+}
+.card-link+.card-link{
+  margin-left:1.25rem
+}
+.card>.list-group:first-child .list-group-item:first-child{
+  border-top-right-radius:.5rem;
+  border-top-left-radius:.5rem
+}
+.card>.list-group:last-child .list-group-item:last-child{
+  border-bottom-right-radius:.5rem;
+  border-bottom-left-radius:.5rem
+}
+.card-header{
+  padding:.75rem 1.25rem;
+  margin-bottom:0;
+  background-color:#f7f7f9;
+  border-bottom:1px solid rgba(0,0,0,.125)
+}
+.card-header:first-child{
+  border-radius:calc(.5rem - 1px) calc(.5rem - 1px) 0 0
+}
+.card-footer{
+  padding:.75rem 1.25rem;
+  background-color:#f7f7f9;
+  border-top:1px solid rgba(0,0,0,.125)
+}
+.card-footer:last-child{
+  border-radius:0 0 calc(.5rem - 1px) calc(.5rem - 1px)
+}
+.card-header-tabs{
+  margin-right:-.625rem;
+  margin-bottom:-.75rem;
+  margin-left:-.625rem;
+  border-bottom:0
+}
+.card-header-pills{
+  margin-right:-.625rem;
+  margin-left:-.625rem
+}
+.card-primary{
+  background-color:#0275d8;
+  border-color:#0275d8
+}
+.card-primary .card-footer,.card-primary .card-header{
+  background-color:transparent
+}
+.card-success{
+  background-color:#5cb85c;
+  border-color:#5cb85c
+}
+.card-success .card-footer,.card-success .card-header{
+  background-color:transparent
+}
+.card-info{
+  background-color:#5bc0de;
+  border-color:#5bc0de
+}
+.card-info .card-footer,.card-info .card-header{
+  background-color:transparent
+}
+.card-warning{
+  background-color:#f0ad4e;
+  border-color:#f0ad4e
+}
+.card-warning .card-footer,.card-warning .card-header{
+  background-color:transparent
+}
+.card-danger{
+  background-color:#d9534f;
+  border-color:#d9534f
+}
+.card-danger .card-footer,.card-danger .card-header{
+  background-color:transparent
+}
+.card-outline-primary{
+  background-color:transparent;
+  border-color:#0275d8
+}
+.card-outline-secondary{
+  background-color:transparent;
+  border-color:#ccc
+}
+.card-outline-info{
+  background-color:transparent;
+  border-color:#5bc0de
+}
+.card-outline-success{
+  background-color:transparent;
+  border-color:#5cb85c
+}
+.card-outline-warning{
+  background-color:transparent;
+  border-color:#f0ad4e
+}
+.card-outline-danger{
+  background-color:transparent;
+  border-color:#d9534f
+}
+.card-inverse{
+  color:rgba(255,255,255,.65)
+}
+.card-inverse .card-footer,.card-inverse .card-header{
+  background-color:transparent;
+  border-color:rgba(255,255,255,.2)
+}
+.card-inverse .card-blockquote,.card-inverse .card-footer,.card-inverse .card-header,.card-inverse .card-title{
+  color:#fff
+}
+.card-inverse .card-blockquote .blockquote-footer,.card-inverse .card-link,.card-inverse .card-subtitle,.card-inverse .card-text{
+  color:rgba(255,255,255,.65)
+}
+.card-inverse .card-link:focus,.card-inverse .card-link:hover{
+  color:#fff
+}
+.card-blockquote{
+  padding:0;
+  margin-bottom:0;
+  border-left:0
+}
+.card-img{
+  border-radius:calc(.5rem - 1px)
+}
+.card-img-overlay{
+  position:absolute;
+  top:0;
+  right:0;
+  bottom:0;
+  left:0;
+  padding:1.25rem
+}
+.card-img-top{
+  border-top-right-radius:calc(.5rem - 1px);
+  border-top-left-radius:calc(.5rem - 1px)
+}
+.card-img-bottom{
+  border-bottom-right-radius:calc(.5rem - 1px);
+  border-bottom-left-radius:calc(.5rem - 1px)
+}
+@media (min-width:576px){
+  .card-deck{
+      display:-webkit-box;
+      display:-webkit-flex;
+      display:-ms-flexbox;
+      display:flex;
+      -webkit-flex-flow:row wrap;
+      -ms-flex-flow:row wrap;
+      flex-flow:row wrap
+  }
+  .card-deck .card{
+      display:-webkit-box;
+      display:-webkit-flex;
+      display:-ms-flexbox;
+      display:flex;
+      -webkit-box-flex:1;
+      -webkit-flex:1 0 0%;
+      -ms-flex:1 0 0%;
+      flex:1 0 0%;
+      -webkit-box-orient:vertical;
+      -webkit-box-direction:normal;
+      -webkit-flex-direction:column;
+      -ms-flex-direction:column;
+      flex-direction:column
+  }
+  .card-deck .card:not(:first-child){
+      margin-left:15px
+  }
+  .card-deck .card:not(:last-child){
+      margin-right:15px
+  }
+}
+@media (min-width:576px){
+  .card-group{
+      display:-webkit-box;
+      display:-webkit-flex;
+      display:-ms-flexbox;
+      display:flex;
+      -webkit-flex-flow:row wrap;
+      -ms-flex-flow:row wrap;
+      flex-flow:row wrap
+  }
+  .card-group .card{
+      -webkit-box-flex:1;
+      -webkit-flex:1 0 0%;
+      -ms-flex:1 0 0%;
+      flex:1 0 0%
+  }
+  .card-group .card+.card{
+      margin-left:0;
+      border-left:0
+  }
+  .card-group .card:first-child{
+      border-bottom-right-radius:0;
+      border-top-right-radius:0
+  }
+  .card-group .card:first-child .card-img-top{
+      border-top-right-radius:0
+  }
+  .card-group .card:first-child .card-img-bottom{
+      border-bottom-right-radius:0
+  }
+  .card-group .card:last-child{
+      border-bottom-left-radius:0;
+      border-top-left-radius:0
+  }
+  .card-group .card:last-child .card-img-top{
+      border-top-left-radius:0
+  }
+  .card-group .card:last-child .card-img-bottom{
+      border-bottom-left-radius:0
+  }
+  .card-group .card:not(:first-child):not(:last-child){
+      border-radius:0
+  }
+  .card-group .card:not(:first-child):not(:last-child) .card-img-bottom,.card-group .card:not(:first-child):not(:last-child) .card-img-top{
+      border-radius:0
+  }
+}
+.card-columns{
+  -webkit-column-gap:1rem;
+  -moz-column-gap:1rem;
+  column-gap:1rem
+}
+.card-columns .card{
+  display:inline-block;
+  width:100%;
+  margin-bottom:1rem
+}
+
+/* WordPress adaptation:
+ * cannot have more than 2 cards width because left content is always between 616-750px
+ */
+@media (min-width:576px){
+  .card-columns{
+      -webkit-column-count:2;
+      -moz-column-count:2;
+      column-count:2;
+      -webkit-column-gap:1.25rem;
+      -moz-column-gap:1.25rem;
+      column-gap:1.25rem
+  }
+}
+

--- a/includes/help/README.html
+++ b/includes/help/README.html
@@ -21,9 +21,11 @@
 </ul>
 <h3 id="components">Components</h3>
 <ul>
+<li><a href="#callouts">Callouts</a></li>
 <li><a href="#icons">Icons</a></li>
 <li><a href="#button-groups">Button Groups</a></li>
 <li><a href="#button-dropdowns">Button Dropdowns</a></li>
+<li><a href="#cards">Cards</a></li>
 <li><a href="#navs">Navs</a></li>
 <li><a href="#breadcrumbs">Breadcrumbs</a></li>
 <li><a href="#labels">Labels</a></li>
@@ -746,6 +748,66 @@
 <p><a href="http://getbootstrap.com/css/#responsive-utilities">Bootstrap responsive utilities documentation</a></p>
 <hr>
 <h3 id="components">Components</h3>
+<h3 id="callouts">Callouts</h3>
+<pre><code>[callout type=&quot;default&quot; size=&quot;lg&quot;] ... [/callout]
+</code></pre><h4 id="-callout-parameters">[callout] parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Description</th>
+<th>Required</th>
+<th>Values</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>type</td>
+<td>The type of the callout</td>
+<td>optional</td>
+<td>default, primary, success, info, warning, danger</td>
+<td>default</td>
+</tr>
+<tr>
+<td>size</td>
+<td>Modifies the amount of left margin before the callout</td>
+<td>optional</td>
+<td>xl, lg, md, sm, xs</td>
+<td>normal</td>
+</tr>
+<tr>
+<td>transparent background</td>
+<td>Whether background is 30% transparent</td>
+<td>optional</td>
+<td>true, false</td>
+<td>false</td>
+</tr>
+<tr>
+<td>disabled</td>
+<td>Whether a disabled effect applies</td>
+<td>optional</td>
+<td>true, false</td>
+<td>false</td>
+</tr>
+<tr>
+<td>xclass</td>
+<td>Any extra classes you want to add</td>
+<td>optional</td>
+<td>any text</td>
+<td>none</td>
+</tr>
+<tr>
+<td>data</td>
+<td>Data attribute and value pairs separated by a comma. Pairs separated by pipe (see example at <a href="#button-dropdowns">Button Dropdowns</a>).</td>
+<td>optional</td>
+<td>any text</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p><a href="http://www.blog.derewonko.com/technology/web/css/twitter-bootstrap-callout-css-styles/">Bootstrap callout integration</a></p>
+<hr>
 <h3 id="icons">Icons</h3>
 <pre><code>[icon type=&quot;arrow-right&quot;]
 </code></pre><h4 id="-icon-parameters">[icon] parameters</h4>
@@ -1083,6 +1145,73 @@
 </tbody>
 </table>
 <p><a href="http://getbootstrap.com/components/#btn-dropdowns">Bootstrap button dropdowns documentation</a></p>
+<hr>
+<h3 id="cards">Cards</h3>
+<p>Cards are like panels but live within their own container. By default, they stack like bricks, in columns, exactly like on Pinterest. More options coming soon.</p>
+<p>Every compoment of a card is optional, however you should not have a footer without a block because its position would not be at the bottom.</p>
+<pre><code>
+[cards]
+  [card]
+    [card-header]
+        ...
+    [/card-header]
+    [card-block]
+        ...
+    [/card-block]
+    [card-footer]
+        ...
+    [/card-footer]
+  [/card]
+[/cards]
+</code></pre><h4 id="-cards-parameters">[card] and [card-block] parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Description</th>
+<th>Required</th>
+<th>Values</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>type</td>
+<td>The type of the card; note that card-block can have their own type, leading to bi-colored cards.</td>
+<td>optional</td>
+<td>default, primary, success, info, warning, danger, link</td>
+<td>default</td>
+</tr>
+<tr>
+<td>xclass</td>
+<td>Any extra classes you want to add</td>
+<td>optional</td>
+<td>any text</td>
+<td>none</td>
+</tr>
+<tr>
+<td>data</td>
+<td>Data attribute and value pairs separated by a comma. Pairs separated by pipe (see example at <a href="#button-dropdowns">Button Dropdowns</a>).</td>
+<td>optional</td>
+<td>any text</td>
+<td>none</td>
+</tr>
+</tbody>
+</table>
+<p><a href="https://v4-alpha.getbootstrap.com/components/card/">Bootstrap 4 Cards documentation</a></p>
+<p>Columns per set of cards is currently dynamic: @screen&lt;576px = 1; @screen&gt;576px = 2; If you want more columns for bigger screens, consider adding this example CSS snippet:</p>
+<pre><code>
+@media (min-width:992px){
+  .card-columns{
+      -webkit-column-count:3;
+      -moz-column-count:3;
+      column-count:3;
+      -webkit-column-gap:1.25rem;
+      -moz-column-gap:1.25rem;
+      column-gap:1.25rem
+  }
+}
+</code></pre>
 <hr>
 <h3 id="navs">Navs</h3>
 <pre><code>[nav type=&quot;pills&quot;]
@@ -1913,7 +2042,18 @@
 <p><a href="http://getbootstrap.com/components/#list-group">Bootstrap list groups documentation</a></p>
 <hr>
 <h3 id="panels">Panels</h3>
-<pre><code>[panel type=&quot;info&quot; heading=&quot;Panel Title&quot; footer=&quot;Footer text&quot;] ... [/panel]
+<pre><code>
+[panel]
+  [panel-header]
+      ...
+  [/panel-header]
+  [panel-body]
+      ...
+  [/panel-body]
+  [panel-footer]
+      ...
+  [/panel-footer]
+[/row]
 </code></pre><h4 id="-panel-parameters">[panel] parameters</h4>
 <table>
 <thead>
@@ -1932,27 +2072,6 @@
 <td>optional</td>
 <td>default, primary, success, info, warning, danger, link</td>
 <td>default</td>
-</tr>
-<tr>
-<td>heading</td>
-<td>The panel heading</td>
-<td>optional</td>
-<td>any text</td>
-<td>none</td>
-</tr>
-<tr>
-<td>title</td>
-<td>Whether the panel heading should have a title tag around it</td>
-<td>optional</td>
-<td>true, false</td>
-<td>false</td>
-</tr>
-<tr>
-<td>footer</td>
-<td>The panel footer text if desired</td>
-<td>optional</td>
-<td>any text</td>
-<td>none</td>
 </tr>
 <tr>
 <td>xclass</td>


### PR DESCRIPTION
* added row-container
* modified panel
* added styles auto loading for callout and cards
* I deliberatly added my name and version 3.4.0 in the comments but feel free to change that according to your own rules

@todo: maybe minify the styles?

+ callout:
  - these are the callout from Bootstrap docs, plus a nice background, plus transparency and disabled options.
  - help updated
  - todo: none

+ cards:
  - these are the cards from bootstrap 4, in a Pinterest column like fashion.
  - help updated
  - todo: add more options like set of cards, no radius etc

+ row-container:
  - for rows inside a column, this fix a bug where the row would close too early. We just needed another shortcode for rows that's it.
  - usage: [row][column][row-container][/row-container]..[/column][/row]
  - todo: integrate an usage example in help.html

+ panel:
  - now it's a real container with panel-heading, panel-body, panel-footer as per bootstrap definition.
  - help updated
  - todo: inform current users that the syntax has changed. They do not lose their data, but they need to rewrite the shortcodes though.